### PR TITLE
Ignore false positive log messages

### DIFF
--- a/usr/libexec/systemcheck/check_services.bsh
+++ b/usr/libexec/systemcheck/check_services.bsh
@@ -159,6 +159,11 @@ check_journal() {
    ignore_pattern_add "wireplumber.service: Bound to unit pipewire.service, but unit isn't active."
    ignore_pattern_add "Dependency failed for wireplumber.service - Multimedia Service Session Manager."
    ignore_pattern_add "wireplumber.service: Job wireplumber.service/start failed with result 'dependency'."
+   # false positives
+   ignore_pattern_add "audit\\[[0-9]*\\]: CRED_.* res=success"
+   ignore_pattern_add "AVC apparmor=\"ALLOWED\""
+   ignore_pattern_add "INFO.*Whonix firewall timesync-fail-closed mode"
+   ignore_pattern_add "audit: CONFIG_CHANGE op=set audit_failure=1"
 
    grep -Ei  "$pattern_list"    -- "$TEMP_DIR/journalctl_output.txt"  | tee -- "$TEMP_DIR/journalctl_matched.txt"  >/dev/null || true
 


### PR DESCRIPTION
https://forums.whonix.org/t/systemcheck-fails-for-unclear-reason/21424/2

This pull request ignores clearly false positives. After that, few more "failures" are still there:
```
Mar 08 13:59:26 host augenrules[1014]: failure 1
Mar 08 13:59:26 host augenrules[1014]: failure 1
Mar 08 13:59:26 host augenrules[1014]: failure 1
```
```
Mar 08 14:05:23 host auditd[866]: Error receiving audit netlink packet (No buffer space available)
```
Those I'm not sure if they are also false positives, or actual issues.

## Changes

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #

PS what issue reference should this be? on github? AFAIK Whonix and Kicksecure uses currently forum for issue tracking, which don't have issue numbers...
